### PR TITLE
Add 'react-lifecycles-compat' to externals

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,7 +48,7 @@ export default {
     },
     output
   ),
-  external: ['react', 'prop-types', 'final-form', 'react-final-form'],
+  external: ['react', 'prop-types', 'final-form', 'react-final-form', 'react-lifecycles-compat'],
   plugins: [
     resolve({ jsnext: true, main: true }),
     flow(),


### PR DESCRIPTION
This addresses #43.

I hadn't heard back in that issue regarding this change, but given that every other dependency in this project is externalized, I assumed the intent was for this dependency to be external as well.