### PR TITLE
Externalize babel helpers using @babel/runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,6 +21,7 @@
   },
   "plugins": [
     "@babel/plugin-transform-flow-strip-types",
+    "@babel/plugin-transform-runtime",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
     "@babel/plugin-proposal-class-properties",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3503,7 +3503,8 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3984,6 +3985,7 @@
       "version": "3.3.4",
       "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
         "from": "~0",
@@ -4330,7 +4332,8 @@
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -7681,7 +7684,8 @@
     "map-stream": {
       "version": "0.1.0",
       "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -8874,6 +8878,7 @@
       "version": "0.0.11",
       "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
       "requires": {
         "through": "~2.3"
       }
@@ -9737,6 +9742,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
       "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
       "requires": {
         "event-stream": "=3.3.4"
       }
@@ -11351,12 +11357,14 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
     },
     "spawn-command-with-kill": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command-with-kill/-/spawn-command-with-kill-1.0.2.tgz",
       "integrity": "sha512-EPzhF/ZO19xzZ1RCyrNorAal5o5FoZoXqHeybQm4vyfMmNbOU5cvfKQsTuspcBVilL5QDmybYpwkj9/GgaEd8Q==",
+      "dev": true,
       "requires": {
         "ps-tree": "^1.2.0",
         "spawn-command": "^0.0.2-1"
@@ -11421,6 +11429,7 @@
       "version": "0.3.3",
       "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -11506,6 +11515,7 @@
       "version": "0.0.4",
       "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
       "requires": {
         "duplexer": "~0.1.1"
       }
@@ -11797,7 +11807,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -784,6 +784,18 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
@@ -915,10 +927,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
-      "dev": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -926,8 +937,7 @@
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-          "dev": true
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -3493,8 +3503,7 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3972,19 +3981,17 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
-      "dev": true,
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "requires": {
-        "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
       }
     },
     "exec-sh": {
@@ -4237,12 +4244,6 @@
         "write": "^0.2.1"
       }
     },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-      "dev": true
-    },
     "flow-bin": {
       "version": "0.83.0",
       "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.83.0.tgz",
@@ -4329,8 +4330,7 @@
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -7679,10 +7679,9 @@
       "dev": true
     },
     "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-      "dev": true
+      "version": "0.1.0",
+      "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -8875,7 +8874,6 @@
       "version": "0.0.11",
       "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
       "requires": {
         "through": "~2.3"
       }
@@ -9736,12 +9734,11 @@
       }
     },
     "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
       "requires": {
-        "event-stream": "~3.3.0"
+        "event-stream": "=3.3.4"
       }
     },
     "pseudomap": {
@@ -11354,16 +11351,14 @@
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
-      "dev": true
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
     },
     "spawn-command-with-kill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-command-with-kill/-/spawn-command-with-kill-1.0.0.tgz",
-      "integrity": "sha1-gDrXny9W5E3ZJhg3aKrC+ux9DOY=",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command-with-kill/-/spawn-command-with-kill-1.0.2.tgz",
+      "integrity": "sha512-EPzhF/ZO19xzZ1RCyrNorAal5o5FoZoXqHeybQm4vyfMmNbOU5cvfKQsTuspcBVilL5QDmybYpwkj9/GgaEd8Q==",
       "requires": {
-        "ps-tree": "^1.1.0",
+        "ps-tree": "^1.2.0",
         "spawn-command": "^0.0.2-1"
       }
     },
@@ -11423,10 +11418,9 @@
       "dev": true
     },
     "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
+      "version": "0.3.3",
+      "resolved": "http://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
         "through": "2"
       }
@@ -11509,13 +11503,11 @@
       "dev": true
     },
     "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "dev": true,
+      "version": "0.0.4",
+      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
+        "duplexer": "~0.1.1"
       }
     },
     "string-argv": {
@@ -11805,8 +11797,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.0.0",
+    "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@types/react": "^16.4.16",
     "babel-core": "^7.0.0-bridge.0",
@@ -75,8 +77,7 @@
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-uglify": "^6.0.0",
-    "typescript": "^3.1.3",
-    "@babel/preset-flow": "^7.0.0"
+    "typescript": "^3.1.3"
   },
   "peerDependencies": {
     "final-form": ">=4.0.0",
@@ -112,6 +113,7 @@
     }
   ],
   "dependencies": {
+    "@babel/runtime": "^7.2.0",
     "react-lifecycles-compat": "^3.0.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,13 +49,20 @@ export default {
     },
     output
   ),
-  external: [
-    'react',
-    'prop-types',
-    'final-form',
-    'react-final-form',
-    'react-lifecycles-compat'
-  ],
+  external: id => {
+    const externals = [
+      'react',
+      'prop-types',
+      'final-form',
+      'react-final-form',
+      'react-lifecycles-compat'
+    ]
+
+    const isBabelRuntime = id.startsWith('@babel/runtime')
+    const isStaticExternal = externals.indexOf(id) > -1
+
+    return isBabelRuntime || isStaticExternal
+  },
   plugins: [
     resolve({ jsnext: true, main: true }),
     flow(),
@@ -76,6 +83,7 @@ export default {
       ],
       plugins: [
         '@babel/plugin-transform-flow-strip-types',
+        '@babel/plugin-transform-runtime',
         '@babel/plugin-syntax-dynamic-import',
         '@babel/plugin-syntax-import-meta',
         '@babel/plugin-proposal-class-properties',
@@ -90,7 +98,8 @@ export default {
         '@babel/plugin-proposal-export-namespace-from',
         '@babel/plugin-proposal-numeric-separator',
         '@babel/plugin-proposal-throw-expressions'
-      ]
+      ],
+      runtimeHelpers: true
     }),
     umd
       ? replace({


### PR DESCRIPTION
### tl,dr:

This reduces the ES module size from `10664` to `9274` bytes (~13%) by externalizing babel runtime helper functions.

Many people are using these helper functions elsewhere. By externalizing them, folks can take advantage of only including a single copy (as opposed to the additional copy that was inlined by `react-final-form-arrays`).

### Details

[react-final-form-arrays.es.js](https://unpkg.com/react-final-form-arrays@2.0.1/dist/react-final-form-arrays.es.js) goes from something like this:

```js
import { Component, createElement } from 'react';
import { polyfill } from 'react-lifecycles-compat';
import { fieldSubscriptionItems, version, ARRAY_ERROR } from 'final-form';
import { version as version$1, withReactFinalForm } from 'react-final-form';

function _objectWithoutPropertiesLoose(source, excluded) {
  if (source == null) return {};
  var target = {};
  var sourceKeys = Object.keys(source);
  var key, i;

  for (i = 0; i < sourceKeys.length; i++) {
    key = sourceKeys[i];
    if (excluded.indexOf(key) >= 0) continue;
    target[key] = source[key];
  }

  return target;
}

// Lots of other babel helpers (not shown).
```

to this:

```js
import _extends from '@babel/runtime/helpers/extends';
import _objectWithoutPropertiesLoose from '@babel/runtime/helpers/objectWithoutPropertiesLoose';
import { Component, createElement } from 'react';
import _inheritsLoose from '@babel/runtime/helpers/inheritsLoose';
import _assertThisInitialized from '@babel/runtime/helpers/assertThisInitialized';
import _defineProperty from '@babel/runtime/helpers/defineProperty';
import { polyfill } from 'react-lifecycles-compat';
import { fieldSubscriptionItems, version, ARRAY_ERROR } from 'final-form';
import { version as version$1, withReactFinalForm } from 'react-final-form';

//      
function diffSubscription (a, b, keys) {
  if (a) {
    if (b) {
      // $FlowFixMe
      return keys.some(function (key) {
        return a[key] !== b[key];
      });
    } else {
      return true;
    }
  } else {
    return !!b;
  }
}
```

### Question for maintainers:

When I ran `nps build`, I noticed this console output:

```
[build.umd.main] (!) Missing global variable names
[build.umd.main] Use output.globals to specify browser global variable names corresponding to external modules
[build.umd.main] @babel/runtime/helpers/extends (guessing '_extends')
[build.umd.main] @babel/runtime/helpers/objectWithoutPropertiesLoose (guessing '_objectWithoutPropertiesLoose')
[build.umd.main] @babel/runtime/helpers/inheritsLoose (guessing '_inheritsLoose')
[build.umd.main] @babel/runtime/helpers/assertThisInitialized (guessing '_assertThisInitialized')
[build.umd.main] @babel/runtime/helpers/defineProperty (guessing '_defineProperty')
[build.umd.main] created dist/react-final-form-arrays.umd.js in 855ms
[build.umd.main] nps build.umd.main exited with code 0
```

It appears that `output.globals` in the rollup config maybe should be updated, but I'm not sure so I've left it unchanged.