### PR TITLE
REMOVE FlowType from HOC decorator

### DIFF
--- a/src/FieldArray.js
+++ b/src/FieldArray.js
@@ -243,6 +243,6 @@ polyfill(FieldArray)
 
 const decorated: React.ComponentType<
   FieldArrayProps & ReactContext
-> = withReactFinalForm<FieldArrayProps>(FieldArray)
+> = withReactFinalForm(FieldArray)
 
 export default decorated


### PR DESCRIPTION
Latest version threw an error on start up for React-Native. This was caused by the Type being passed against the HOC.

Passes tests, functions as expected, and resolves the issue