### PR TITLE
:bug: FieldArray incorrect rerender

### DIFF
--- a/src/useFieldArray.js
+++ b/src/useFieldArray.js
@@ -38,7 +38,7 @@ const useFieldArray = (
 
   const validate: FieldValidator = useConstant(
     () => (value, allValues, meta) => {
-      if (!validateProp) return undefined
+      if (!validateProp) return meta && meta.error
       const error = validateProp(value, allValues, meta)
       if (!error || Array.isArray(error)) {
         return error


### PR DESCRIPTION
### What

When validate is not given to FieldArray, it always returns `undefined`, which flush the error came from Field-level validation, and then Field-level revalidate to generate a "new" error. This leads to a double wasting rerender on `FieldArray`

Sementcially, if validate is not given, it should return the `meta.error` which respects field level validation.


### Workaround

```
<FieldArray
  validate={(value, allValue, meta) => meta && meta.error}
/>
```