### PR TITLE
Added tsx generic typing for FieldArray

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,21 +3,21 @@ import { FieldSubscription, FieldState } from 'final-form'
 import { UseFieldConfig } from 'react-final-form'
 export const version: string
 
-export interface FieldArrayRenderProps<T extends HTMLElement> {
+export interface FieldArrayRenderProps<FieldValue, T extends HTMLElement> {
   fields: {
     forEach: (iterator: (name: string, index: number) => void) => void
-    insert: (index: number, value: any) => void
-    map: (iterator: (name: string, index: number) => any) => any[]
+    insert: (index: number, value: FieldValue) => void
+    map: <R>(iterator: (name: string, index: number) => R) => R[]
     move: (from: number, to: number) => void
-    update: (index: number, value: any) => void
+    update: (index: number, value: FieldValue) => void
     name: string
-    pop: () => any
-    push: (value: any) => void
-    remove: (index: number) => any
-    shift: () => any
+    pop: () => FieldValue
+    push: (value: FieldValue) => void
+    remove: (index: number) => FieldValue
+    shift: () => FieldValue
     swap: (indexA: number, indexB: number) => void
-    unshift: (value: any) => void
-  } & FieldState
+    unshift: (value: FieldValue) => void
+  } & FieldState<FieldValue[]>
   meta: Partial<{
     // TODO: Make a diff of `FieldState` without all the functions
     active: boolean
@@ -42,19 +42,29 @@ export interface RenderableProps<T> {
   render?: (props: T) => React.ReactNode
 }
 
-export interface UseFieldArrayConfig extends UseFieldConfig {
+export interface UseFieldArrayConfig<FieldValue>
+  extends UseFieldConfig<FieldValue> {
   isEqual?: (a: any[], b: any[]) => boolean
 }
 
-export interface FieldArrayProps<T extends HTMLElement>
-  extends UseFieldArrayConfig,
-    RenderableProps<FieldArrayRenderProps<T>> {
+export interface FieldArrayProps<FieldValue, T extends HTMLElement>
+  extends UseFieldArrayConfig<FieldValue>,
+    RenderableProps<FieldArrayRenderProps<FieldValue, T>> {
   name: string
   [otherProp: string]: any
 }
 
-export const FieldArray: React.FC<FieldArrayProps<any>>
-export function useFieldArray<T extends HTMLElement>(
+export const FieldArray: <
+  FieldValue = any,
+  T extends HTMLElement = HTMLElement
+>(
+  props: FieldArrayProps<FieldValue, T>
+) => React.ReactElement
+
+export function useFieldArray<
+  FieldValue = any,
+  T extends HTMLElement = HTMLElement
+>(
   name: string,
-  config: UseFieldArrayConfig
-): FieldArrayRenderProps<T>
+  config: UseFieldArrayConfig<FieldValue>
+): FieldArrayRenderProps<FieldValue, T>


### PR DESCRIPTION
Depends on:
https://github.com/final-form/react-final-form/pull/522
https://github.com/final-form/final-form/pull/225

This should allow for types to be passed to a `FieldArray` like so:

```typescript
<FieldArray<{ firstName: string, lastName: string }> name="people">
  {({ fields: { value } }) => {
      // value will have a type now
  }}
</FieldArray>
```