### PR TITLE
Documented and Typed fields.value

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ Updates a value of the specified index of the array field.
 
 A function to add a value to the beginning of the array.
 
+#### `fields.value: any[]`
+
+The value of the array. Should be treated as readonly.
+
 #### `meta.active?: boolean`
 
 [See the 🏁 Final Form docs on `active`](https://github.com/final-form/final-form#active-boolean).

--- a/src/FieldArray.test.js
+++ b/src/FieldArray.test.js
@@ -682,6 +682,28 @@ describe('FieldArray', () => {
     expect(getByTestId('values')).toHaveTextContent('')
   })
 
+  it('should provide value', () => {
+    const renderArray = jest.fn(() => <div />)
+    render(
+      <Form
+        onSubmit={onSubmitMock}
+        mutators={arrayMutators}
+        subscription={{}}
+        initialValues={{ foo: ['a', 'b', 'c'] }}
+      >
+        {() => (
+          <form>
+            <FieldArray name="foo">{renderArray}</FieldArray>
+          </form>
+        )}
+      </Form>
+    )
+    expect(renderArray).toHaveBeenCalled()
+    expect(renderArray).toHaveBeenCalledTimes(1)
+
+    expect(renderArray.mock.calls[0][0].fields.value).toEqual(['a', 'b', 'c'])
+  })
+
   // it('should respect record-level validation', () => {
   //   // https://github.com/final-form/react-final-form-arrays/pull/84
   //   const { getByTestId, getByText } = render(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ export interface FieldArrayRenderProps<FieldValue, T extends HTMLElement> {
     shift: () => FieldValue
     swap: (indexA: number, indexB: number) => void
     unshift: (value: FieldValue) => void
+    value: FieldValue[]
   } & FieldState<FieldValue[]>
   meta: Partial<{
     // TODO: Make a diff of `FieldState` without all the functions

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -34,7 +34,8 @@ export type FieldArrayRenderProps = {
     remove: (index: number) => any,
     shift: () => any,
     swap: (indexA: number, indexB: number) => void,
-    unshift: (value: any) => void
+    unshift: (value: any) => void,
+    value: any[]
   },
   meta: Meta
 }


### PR DESCRIPTION
Since the hooks rewrite, `fields.value` has been present, but it was undocumented and untyped. This PR remedies that.

It's a shame that there's no good way to force it to be readonly/immutable. I guess we'll just have to hope devs are smart enough to not try to use `fields.push()` rather than `fields.value.push()`.

Fixes #95. Fixes #13.