### PR TITLE
Update beautiful dnd example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ const MyForm = () => (
 Demostrates how to use `<FieldArray/>` to render an array of inputs, as well as
 use `push`, `pop`, and `remove` mutations.
 
-### [React Beautiful DnD Example](https://codesandbox.io/s/8k0ykyr7z9)
+### [React Beautiful DnD Example](https://codesandbox.io/s/678pj)
 
 Demostrates how to integrate the simple example with [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd)
 


### PR DESCRIPTION
### Fix React beautiful dnd example

Thanks, for the library :) I've very much enjoyed using final-forms. The current example with `react-beautiful-dnd` [here](https://codesandbox.io/s/8k0ykyr7z9) uses the following for `makeOnDragEndFunction` drop:
```
fields.swap(result.source.index, result.destination.index);
```
This has the effect, that if you start off with `#1, #2, #3, #4` and you move `#4` to the second position, then after the drop, `#2` jumps to the end position, which is unexpected. I have forked the example on sandbox, and updated this line to become:
```
fields.move(result.source.index, result.destination.index);
```
and also updated the link in the readme to the new sandbox.