### PR TITLE
Avoid whole-form validation when no field validation is provided.

### DIFF
--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -3,7 +3,7 @@ import { act, render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import arrayMutators from 'final-form-arrays'
 import { ErrorBoundary } from './testUtils'
-import { Form } from 'react-final-form'
+import { Form, useField } from 'react-final-form'
 import useFieldArray from './useFieldArray'
 
 const onSubmitMock = (values: any) => {}
@@ -66,11 +66,10 @@ describe('FieldArray', () => {
     // This prevents final-form from tracking this field as having a validator,
     // which would trigger unnecessary form-wide validation.
     
-    const fieldArraySpy = jest.fn()
+    const useFieldSpy = jest.spyOn(require('react-final-form'), 'useField')
     
     const MyFieldArray = () => {
       const fieldArray = useFieldArray('names')
-      fieldArraySpy(fieldArray)
       return null
     }
 
@@ -88,16 +87,13 @@ describe('FieldArray', () => {
       </Form>
     )
 
-    // Get the last call before mutations
-    const lastCallBeforeMutations = fieldArraySpy.mock.calls.length - 1
+    // Verify that useField was called with validate: undefined
+    const useFieldCalls = useFieldSpy.mock.calls
+    const relevantCall = useFieldCalls.find(call => call[0] === 'names')
+    expect(relevantCall).toBeDefined()
+    expect(relevantCall![1].validate).toBeUndefined()
     
-    // Push items to array - these should not cause validation issues
-    act(() => fieldArraySpy.mock.calls[lastCallBeforeMutations][0].fields.push('alice'))
-    act(() => fieldArraySpy.mock.calls[lastCallBeforeMutations][0].fields.push('bob'))
-    
-    // Verify the items were added
-    const lastCall = fieldArraySpy.mock.calls[fieldArraySpy.mock.calls.length - 1]
-    expect(lastCall[0].fields.length).toBe(2)
+    useFieldSpy.mockRestore()
   })
 
   it('should call validator when validate prop is provided', () => {

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -40,7 +40,7 @@ const useFieldArray = (
     }, {} as Record<string, Function>
     ), [name, formMutators])
 
-  const validate: FieldValidator = useConstant(() =>
+  const validate: FieldValidator | undefined = useConstant(() =>
     !validateProp
       ? undefined
       : (value: any, allValues: any, meta: any) => {

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -40,19 +40,20 @@ const useFieldArray = (
     }, {} as Record<string, Function>
     ), [name, formMutators])
 
-  const validate: FieldValidator = useConstant(
-    () => (value: any, allValues: any, meta: any) => {
-      if (!validateProp) return undefined
-      const error = validateProp(value, allValues, meta)
-      if (!error || Array.isArray(error)) {
-        return error
-      } else {
-        const arrayError: any[] = []
-          // gross, but we have to set a string key on the array
-          ; (arrayError as any)[ARRAY_ERROR] = error
-        return arrayError
-      }
-    }
+  const validate: FieldValidator = useConstant(() =>
+    !validateProp
+      ? undefined
+      : (value: any, allValues: any, meta: any) => {
+          const error = validateProp(value, allValues, meta)
+          if (!error || Array.isArray(error)) {
+            return error
+          } else {
+            const arrayError: any[] = []
+            // gross, but we have to set a string key on the array
+            ; (arrayError as any)[ARRAY_ERROR] = error
+            return arrayError
+          }
+        }
   )
 
   const fieldState = useField(name, {


### PR DESCRIPTION
Having a default validation function provided - even when no field validator is given - results in whole form validation being triggered each time array items are altered:

https://github.com/final-form/final-form/blob/9c732e27f29e82ea55b7c0f8a6cafb208c96ccb9/src/FinalForm.js#L897

This PR fixes it, by ensuring `undefined` is passed in case no validation is provided by the user.

<!--

👋 Hey, thanks for your interest in contributing to 🏁 React Final Form Arrays!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/final-form/react-final-form-arrays/blob/master/.github/CONTRIBUTING.md

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases for form field array validation to ensure validators are properly executed when configured and correctly handled when validation is not configured.

* **Refactor**
  * Refactored the field array validation system to improve how validators are conditionally initialized and executed, with corresponding enhancements to error handling during field operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->