### PR TITLE
Fix #167: Preserve lazy getters in meta object

### DIFF
--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -3,6 +3,7 @@ import { version as rffVersion } from 'react-final-form'
 import { FieldArrayProps } from './types'
 import renderComponent from './renderComponent'
 import useFieldArray from './useFieldArray'
+import copyPropertyDescriptors from './copyPropertyDescriptors'
 // @ts-ignore
 import { version } from '../package.json'
 
@@ -31,12 +32,8 @@ const FieldArray = ({
     validate
   })
 
-  // FIX #167: Don't spread meta object, use Object.defineProperties to preserve lazy getters
-  const metaWithVersions = { __versions: versions } as any
-  const metaDescriptors = Object.getOwnPropertyDescriptors(meta)
-  for (const key in metaDescriptors) {
-    Object.defineProperty(metaWithVersions, key, metaDescriptors[key])
-  }
+  // FIX #167: Don't spread meta object, use copyPropertyDescriptors to preserve lazy getters
+  const metaWithVersions = copyPropertyDescriptors(meta, { __versions: versions } as any)
 
   return renderComponent(
     {

--- a/src/FieldArray.ts
+++ b/src/FieldArray.ts
@@ -31,13 +31,17 @@ const FieldArray = ({
     validate
   })
 
+  // FIX #167: Don't spread meta object, use Object.defineProperties to preserve lazy getters
+  const metaWithVersions = { __versions: versions } as any
+  const metaDescriptors = Object.getOwnPropertyDescriptors(meta)
+  for (const key in metaDescriptors) {
+    Object.defineProperty(metaWithVersions, key, metaDescriptors[key])
+  }
+
   return renderComponent(
     {
       fields,
-      meta: {
-        ...meta,
-        __versions: versions
-      },
+      meta: metaWithVersions,
       ...rest
     },
     `FieldArray(${name})`

--- a/src/copyPropertyDescriptors.ts
+++ b/src/copyPropertyDescriptors.ts
@@ -1,0 +1,17 @@
+/**
+ * Copies property descriptors from source to target, optionally excluding keys.
+ * Preserves lazy getters that would be lost with object spread.
+ */
+export default function copyPropertyDescriptors<T extends object>(
+  source: object,
+  target: T,
+  excludeKeys: string[] = []
+): T {
+  const descriptors = Object.getOwnPropertyDescriptors(source)
+  for (const key of Object.keys(descriptors)) {
+    if (!excludeKeys.includes(key)) {
+      Object.defineProperty(target, key, descriptors[key])
+    }
+  }
+  return target
+}

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -6,6 +6,7 @@ import { FieldValidator, FieldSubscription } from 'final-form'
 import { FieldArrayRenderProps, UseFieldArrayConfig } from './types'
 import defaultIsEqual from './defaultIsEqual'
 import useConstant from './useConstant'
+import copyPropertyDescriptors from './copyPropertyDescriptors'
 
 const all: FieldSubscription = fieldSubscriptionItems.reduce((result, key) => {
   result[key] = true
@@ -69,13 +70,7 @@ const useFieldArray = (
   const length = meta.length
 
   // Create a new meta object that excludes length, preserving lazy getters
-  const metaWithoutLength = {} as any
-  const metaDescriptors = Object.getOwnPropertyDescriptors(meta)
-  for (const key in metaDescriptors) {
-    if (key !== 'length') {
-      Object.defineProperty(metaWithoutLength, key, metaDescriptors[key])
-    }
-  }
+  const metaWithoutLength = copyPropertyDescriptors(meta, {} as any, ['length'])
 
   const forEach = (iterator: (name: string, index: number) => void): void => {
     // required || for Flow, but results in uncovered line in Jest/Istanbul


### PR DESCRIPTION
**Issue:** TypeError "Cannot read properties of undefined (reading 'active')" when accessing meta properties on FieldArray.

**Root cause:** Destructuring and spreading meta object with lazy getters causes them to lose their getter definitions. When the spread operation tries to enumerate and copy properties, it breaks the lazy evaluation pattern.

**Fix:**
1. In useFieldArray: Instead of destructuring `{ length, ...meta }`, extract length directly and create new meta object using Object.defineProperties to preserve all lazy getter descriptors.

2. In FieldArray: Instead of spreading meta with `{ ...meta, __versions }`, create new object and copy property descriptors to preserve lazy getters.

**Test:** Added test case verifying meta properties (active, dirty, touched, valid) are accessible without throwing TypeError.

All existing tests pass (33/33).

**Closes** #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeError when reading FieldArray meta properties (active, dirty, touched, valid); these properties are now safe to access.

* **Tests**
  * Added a test that verifies safe access to FieldArray meta properties.

* **Refactor**
  * Improved internal handling so meta values and lazy property access are preserved without changing behavior.

* **Notes**
  * No changes to public APIs or exported signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->