### PR TITLE
Test: Regression tests for form.getFieldState data preservation after remove (#165)

### DIFF
--- a/src/FieldArray.test.tsx
+++ b/src/FieldArray.test.tsx
@@ -966,4 +966,107 @@ describe('FieldArray', () => {
     expect('touched' in metaSnapshot).toBe(true)
     expect('valid' in metaSnapshot).toBe(true)
   })
+
+  it('should preserve data property in field state after remove', async () => {
+    // Reproduces: https://github.com/final-form/react-final-form-arrays/issues/165
+    // form.getFieldState is corrupted after arrays.remove - data is lost for shifted fields
+    let formRef: any = null
+
+    const { getByText } = render(
+      <Form
+        onSubmit={onSubmitMock}
+        mutators={{
+          ...arrayMutators,
+          setFieldData: ([name, data]: [string, any], state: any) => {
+            if (state.fields[name]) {
+              state.fields[name].data = data
+            }
+          }
+        }}
+        initialValues={{ customers: ['Alice', 'Bob'] }}
+      >
+        {({ form }) => {
+          formRef = form
+          return (
+            <form>
+              <FieldArray name="customers">
+                {({ fields }) =>
+                  fields.map((name, index) => (
+                    <div key={index}>
+                      <Field name={name} component="input" />
+                      <button
+                        type="button"
+                        onClick={() => fields.remove(index)}
+                      >
+                        Remove {index}
+                      </button>
+                    </div>
+                  ))
+                }
+              </FieldArray>
+            </form>
+          )
+        }}
+      </Form>
+    )
+
+    // Set data on both fields
+    act(() => {
+      formRef.mutators.setFieldData('customers[0]', { disabled: true })
+      formRef.mutators.setFieldData('customers[1]', { disabled: true })
+    })
+
+    // Remove element at index 0
+    act(() => {
+      fireEvent.click(getByText('Remove 0'))
+    })
+
+    // After removal, customers[1] becomes customers[0]
+    // Its data property must be preserved — not undefined or {}
+    const fieldState = formRef.getFieldState('customers[0]')
+    expect(fieldState).toBeDefined()
+    expect(fieldState!.data).toEqual({ disabled: true })
+  })
+
+  it('should return defined field state (not undefined) for shifted field immediately after remove', () => {
+    // Edge case: getFieldState should return the field state, not undefined,
+    // even when called synchronously after remove (before React re-renders).
+    // copyField sets lastFieldState: undefined to force re-notification,
+    // but getFieldState(name) returns field.lastFieldState — which would be undefined.
+    let formRef: any = null
+    let removeRef: any = null
+
+    render(
+      <Form
+        onSubmit={onSubmitMock}
+        mutators={arrayMutators}
+        initialValues={{ items: ['a', 'b'] }}
+      >
+        {({ form }) => {
+          formRef = form
+          return (
+            <form>
+              <FieldArray name="items">
+                {({ fields }) => {
+                  removeRef = fields.remove
+                  return fields.map((name, index) => (
+                    <Field key={index} name={name} component="input" />
+                  ))
+                }}
+              </FieldArray>
+            </form>
+          )
+        }}
+      </Form>
+    )
+
+    act(() => {
+      removeRef(0)
+    })
+
+    // After remove + React re-render cycle, getFieldState should be defined
+    const fieldState = formRef.getFieldState('items[0]')
+    expect(fieldState).toBeDefined()
+    expect(fieldState!.value).toBe('b')
+  })
 })


### PR DESCRIPTION
## Summary

Integration tests for https://github.com/final-form/react-final-form-arrays/issues/165.

## Investigation

The bug: `form.getFieldState('customers[0]')` shows `data: {}` after `arrays.remove` removes `customers[0]` and shifts `customers[1]` → `customers[0]`.

**Root cause analysis:**
1. The `remove` mutator's `copyField` correctly spreads `data` from shifted fields ✅
2. Final-form's notification cycle fires synchronously after each mutator call, so `lastFieldState` is updated before `getFieldState` is typically called ✅
3. The behavior appears correct in the current implementation

## What this PR adds

Two integration tests:
1. **Data preservation test**: Sets `data: { disabled: true }` on both array elements, removes index 0, verifies shifted field keeps its data
2. **Field state defined test**: After remove, `getFieldState` returns a defined state with the correct value for the shifted field

These prevent future regressions in the field state copying logic.

Also see: final-form/final-form-arrays#106 (unit test for copyField)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for field array operations to ensure that when items are removed, field data properties are correctly preserved in the remaining field state.
  * Implemented tests to verify field state is immediately available and properly defined after removal operations, confirming data integrity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->