### PR TITLE
Perf: change default FieldArray subscription from 'all' to {length, value, error} (#119)

### DIFF
--- a/src/FieldArray.test.tsx
+++ b/src/FieldArray.test.tsx
@@ -1008,6 +1008,8 @@ describe('FieldArray', () => {
 
     // FieldArray should NOT re-render because `touched` is not in its default subscription
     expect(arrayRenderCount.mock.calls.length).toBe(renderCountAfterMount)
+  })
+
   it('should preserve data property in field state after remove', async () => {
     // Reproduces: https://github.com/final-form/react-final-form-arrays/issues/165
     // form.getFieldState is corrupted after arrays.remove - data is lost for shifted fields

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -8,16 +8,11 @@ import defaultIsEqual from './defaultIsEqual'
 import useConstant from './useConstant'
 import copyPropertyDescriptors from './copyPropertyDescriptors'
 
-const all: FieldSubscription = fieldSubscriptionItems.reduce((result, key) => {
-  result[key] = true
-  return result
-}, {} as FieldSubscription)
-
-// Default subscription for FieldArray: only `length` and `value` are needed
-// for the array to function correctly. Subscribing to everything (the old default)
-// caused severe performance degradation with nested arrays (#119).
-// Users who need additional meta (e.g. error, touched) should pass subscription explicitly.
-const defaultSubscription: FieldSubscription = { length: true, value: true }
+// Default subscription for FieldArray: `length`, `value`, and `error` are included
+// so that array-level validation errors are surfaced without subscribing to everything.
+// The old default (`all`) caused severe performance degradation with nested arrays (#119).
+// Users who need additional meta (e.g. touched, dirty) should pass subscription explicitly.
+const defaultSubscription: FieldSubscription = { length: true, value: true, error: true }
 
 const useFieldArray = (
   name: string,

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -13,10 +13,16 @@ const all: FieldSubscription = fieldSubscriptionItems.reduce((result, key) => {
   return result
 }, {} as FieldSubscription)
 
+// Default subscription for FieldArray: only `length` and `value` are needed
+// for the array to function correctly. Subscribing to everything (the old default)
+// caused severe performance degradation with nested arrays (#119).
+// Users who need additional meta (e.g. error, touched) should pass subscription explicitly.
+const defaultSubscription: FieldSubscription = { length: true, value: true }
+
 const useFieldArray = (
   name: string,
   {
-    subscription = all,
+    subscription = defaultSubscription,
     defaultValue,
     initialValue,
     isEqual = defaultIsEqual,


### PR DESCRIPTION
## Problem

https://github.com/final-form/react-final-form-arrays/issues/119

With large/nested FieldArrays, performance degrades severely because the default subscription was `all` — meaning every FieldArray re-renders on **any** form state change (touched, dirty, valid, errors in unrelated fields, etc.).

With 20 companies × 20 customers = 400 fields, every keystroke or focus event triggered 400+ re-renders.

## Fix

Change the default subscription from `all` to the `defaultSubscription` constant defined in `src/useFieldArray.ts`:

```typescript
const defaultSubscription: FieldSubscription = { length: true, value: true, error: true }
```

This makes FieldArrays only re-render when:
- The array **length** changes (items added/removed)
- The array **values** change
- The array-level **validation error** changes

**Note:** Array-level validation errors are now surfaced by default via `error: true`, so validation feedback continues to work out-of-the-box.

FieldArrays no longer re-render for unrelated form state changes like touched/dirty/valid changes in other parts of the form.

## Breaking Change

Users who rely on `meta.valid`, `meta.touched`, etc. in FieldArray render props (without an explicit subscription) must now add those to their subscription explicitly:

```jsx
<FieldArray name="items" subscription={{ valid: true, touched: true, length: true, value: true, error: true }}>
```

Previously documented workaround: `subscription={{}}` provided similar benefits. The new default behavior (`{ length: true, value: true, error: true }`) is an improvement over that workaround because it includes `error: true` — so array-level validation errors are visible by default.

## Tests

- Updated existing validation test to opt-in to valid subscription explicitly
- Added regression test verifying FieldArray doesn't re-render on unrelated state changes (e.g. touched on another field)
