### PR TITLE
chore: release v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form-arrays",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A component for rendering and editing arrays 🏁 React Final Form",
   "main": "dist/react-final-form-arrays.cjs.js",
   "jsnext:main": "dist/react-final-form-arrays.es.js",
@@ -62,8 +62,8 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "fast-check": "^4.1.1",
-    "final-form": "^5.0.0",
-    "final-form-arrays": "^4.0.0",
+    "final-form": "^5.0.1",
+    "final-form-arrays": "^4.0.1",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -76,7 +76,7 @@
     "raf": "^3.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-final-form": "^7.0.0",
+    "react-final-form": "^7.0.1",
     "rollup": "^4.41.1",
     "rollup-plugin-babel": "^4.4.0",
     "rollup-plugin-commonjs": "^10.1.0",
@@ -88,10 +88,10 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "final-form": "^5.0.0",
-    "final-form-arrays": "^4.0.0",
+    "final-form": "^5.0.1",
+    "final-form-arrays": "^4.0.1",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-final-form": "^7.0.0"
+    "react-final-form": "^7.0.1"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/src/FieldArray.test.tsx
+++ b/src/FieldArray.test.tsx
@@ -133,14 +133,10 @@ describe('FieldArray', () => {
 
     // Find calls after toggle
     const callsAfterToggle = renderArray.mock.calls.slice(2)
-    // strange intermediate state where name has changed but value has not
-    const catsCallWithOdie = callsAfterToggle.find(
-      (call) =>
-        call[0].fields.name === 'cats' && call[0].fields.value?.[0] === 'Odie'
-    )
-    expect(catsCallWithOdie).toBeDefined()
 
-    // all aligned now
+    // With the optimised subscription ({length, value, error} instead of 'all'),
+    // the stale intermediate render (name='cats', value=['Odie']) no longer occurs —
+    // the field re-registers cleanly with the correct value immediately.
     const catsCallWithGarfield = callsAfterToggle.find(
       (call) => call[0].fields.value?.[0] === 'Garfield'
     )


### PR DESCRIPTION
## Release v5.0.0

**Breaking change:** The default FieldArray subscription has changed from `'all'` to `{length, value, error}`. If you rely on other subscription fields (e.g. `dirty`, `touched`) in FieldArray children, pass an explicit `subscription` prop.

### Changes since v4.0.0
- **BREAKING:** Default FieldArray subscription changed from `'all'` to `{length, value, error}` for significantly better performance
- Fix preserve lazy getters in meta object
- Fix types exposure in build process
- Avoid whole-form validation when no field-level validation is provided
- Fix await async `validate` to prevent Promise object as `ARRAY_ERROR`

### Updated peer dependencies
- `final-form`: `^5.0.0` → `^5.0.1`
- `final-form-arrays`: `^4.0.0` → `^4.0.1`
- `react-final-form`: `^7.0.0` → `^7.0.1`