### PR TITLE
feat: add fields.keys for stable React keys in FieldArray (fix #116)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface FieldArrayRenderProps {
   fields: {
     forEach: (iterator: (name: string, index: number) => void) => void
     insert: (index: number, value: any) => void
+    keys: string[]
     map: <T>(iterator: (name: string, index: number) => T) => T[]
     move: (from: number, to: number) => void
     name: string

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -332,5 +332,72 @@ describe('FieldArray', () => {
       expect(keysAfterInsert[1]).toMatch(/^ff-key-/) // new key for inserted item
       expect(keysAfterInsert[1]).not.toBe(originalKey) // different from alice's key
     })
+
+    it('should ignore invalid mutator indexes without desyncing keys', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('bob'))
+
+      const before = spy.mock.calls[spy.mock.calls.length - 1][0].fields
+      const keysBefore = before.keys
+
+      act(() => before.insert(-1, 'bad'))
+      act(() => before.remove(-1))
+      act(() => before.move(0, 99))
+      act(() => before.swap(0, 99))
+
+      const after = spy.mock.calls[spy.mock.calls.length - 1][0].fields
+      expect(after.value).toEqual(['alice', 'bob'])
+      expect(after.keys).toEqual(keysBefore)
+    })
+
+    it('should regenerate keys after external non-tail array changes', () => {
+      const spy = jest.fn()
+      let formApi: any
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form
+          onSubmit={onSubmitMock}
+          mutators={arrayMutators as any}
+          initialValues={{ names: ['alice', 'bob'] }}
+          subscription={{}}
+        >
+          {({ form }) => {
+            formApi = form
+            return (
+              <form>
+                <MyFieldArray />
+              </form>
+            )
+          }}
+        </Form>
+      )
+
+      const keysBefore = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+
+      act(() => formApi.reset({ names: ['zero', 'alice', 'bob'] }))
+
+      const keysAfter = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfter).toHaveLength(3)
+      expect(keysAfter).not.toContain(keysBefore[0])
+      expect(keysAfter).not.toContain(keysBefore[1])
+    })
   })
 })

--- a/src/useFieldArray.test.tsx
+++ b/src/useFieldArray.test.tsx
@@ -133,4 +133,204 @@ describe('FieldArray', () => {
     // Field validation should be called again after mutation
     expect(fieldValidate.mock.calls.length).toBeGreaterThan(initialCalls)
   })
+
+  describe('fields.keys — stable keys for React reconciliation (fix #116)', () => {
+    it('should provide stable keys when removing an item', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      // Push 3 items
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('bob'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('carol'))
+
+      const keysAfterPush = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterPush).toHaveLength(3)
+      expect(keysAfterPush[0]).toMatch(/^ff-key-/)
+      expect(keysAfterPush[1]).toMatch(/^ff-key-/)
+      expect(keysAfterPush[2]).toMatch(/^ff-key-/)
+
+      // Remove the middle item (index 1 = 'bob')
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.remove(1))
+
+      const keysAfterRemove = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterRemove).toHaveLength(2)
+      // First and last items should keep their original keys
+      expect(keysAfterRemove[0]).toBe(keysAfterPush[0])
+      expect(keysAfterRemove[1]).toBe(keysAfterPush[2])
+    })
+
+    it('should generate unique keys on push', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('a'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('b'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('c'))
+
+      const keys = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keys).toHaveLength(3)
+      // All keys should be unique
+      const uniqueKeys = new Set(keys)
+      expect(uniqueKeys.size).toBe(3)
+    })
+
+    it('should update keys correctly on swap', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('bob'))
+
+      const keysBeforeSwap = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      const key0 = keysBeforeSwap[0]
+      const key1 = keysBeforeSwap[1]
+
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.swap(0, 1))
+
+      const keysAfterSwap = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterSwap[0]).toBe(key1)
+      expect(keysAfterSwap[1]).toBe(key0)
+    })
+
+    it('should update keys correctly on move', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('bob'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('carol'))
+
+      const keysBeforeMove = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      const [k0, k1, k2] = keysBeforeMove
+
+      // Move item at index 0 to index 2
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.move(0, 2))
+
+      const keysAfterMove = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterMove[0]).toBe(k1)
+      expect(keysAfterMove[1]).toBe(k2)
+      expect(keysAfterMove[2]).toBe(k0)
+    })
+
+    it('should update keys correctly on pop and shift', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('bob'))
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.push('carol'))
+
+      const keysAfterPush = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      const [k0, k1, k2] = keysAfterPush
+
+      // Pop removes last item
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.pop())
+      const keysAfterPop = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterPop).toHaveLength(2)
+      expect(keysAfterPop[0]).toBe(k0)
+      expect(keysAfterPop[1]).toBe(k1)
+
+      // Shift removes first item
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.shift())
+      const keysAfterShift = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterShift).toHaveLength(1)
+      expect(keysAfterShift[0]).toBe(k1)
+    })
+
+    it('should add keys correctly on unshift and insert', () => {
+      const spy = jest.fn()
+      const MyFieldArray = () => {
+        spy(useFieldArray('names'))
+        return null
+      }
+      render(
+        <Form onSubmit={onSubmitMock} mutators={arrayMutators as any} subscription={{}}>
+          {() => (
+            <form>
+              <MyFieldArray />
+            </form>
+          )}
+        </Form>
+      )
+
+      act(() => spy.mock.calls[0][0].fields.push('alice'))
+      const keysAfterFirstPush = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      const originalKey = keysAfterFirstPush[0]
+
+      // Unshift prepends a new item — existing item's key should be at index 1
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.unshift('zero'))
+      const keysAfterUnshift = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterUnshift).toHaveLength(2)
+      expect(keysAfterUnshift[1]).toBe(originalKey) // alice moved to index 1
+
+      // Insert at index 1 — existing keys should shift around it
+      act(() => spy.mock.calls[spy.mock.calls.length - 1][0].fields.insert(1, 'inserted'))
+      const keysAfterInsert = spy.mock.calls[spy.mock.calls.length - 1][0].fields.keys
+      expect(keysAfterInsert).toHaveLength(3)
+      expect(keysAfterInsert[2]).toBe(originalKey) // alice now at index 2
+      expect(keysAfterInsert[1]).toMatch(/^ff-key-/) // new key for inserted item
+      expect(keysAfterInsert[1]).not.toBe(originalKey) // different from alice's key
+    })
+  })
 })

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -148,6 +148,17 @@ const useFieldArray = (
   }
 
   const move = (from: number, to: number) => {
+    const len = keysRef.current.length
+    if (
+      !Number.isInteger(from) ||
+      !Number.isInteger(to) ||
+      from < 0 ||
+      to < 0 ||
+      from >= len ||
+      to >= len
+    ) {
+      return (mutators as any).move(from, to)
+    }
     const newKeys = [...keysRef.current]
     const [moved] = newKeys.splice(from, 1)
     newKeys.splice(to, 0, moved)
@@ -156,6 +167,17 @@ const useFieldArray = (
   }
 
   const swap = (indexA: number, indexB: number) => {
+    const len = keysRef.current.length
+    if (
+      !Number.isInteger(indexA) ||
+      !Number.isInteger(indexB) ||
+      indexA < 0 ||
+      indexB < 0 ||
+      indexA >= len ||
+      indexB >= len
+    ) {
+      return (mutators as any).swap(indexA, indexB)
+    }
     const newKeys = [...keysRef.current]
     ;[newKeys[indexA], newKeys[indexB]] = [newKeys[indexB], newKeys[indexA]]
     keysRef.current = newKeys

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react'
 import { useForm, useField } from 'react-final-form'
 import { fieldSubscriptionItems, ARRAY_ERROR } from 'final-form'
 import { Mutators } from 'final-form-arrays'
@@ -97,17 +97,16 @@ const useFieldArray = (
   const keyCounter = useRef(0)
   const keysRef = useRef<string[]>([])
 
-  // Sync keys array length with actual field array length.
-  // If external code adds items (e.g., initialValues), generate new keys for them.
+  // Sync keys array length with actual field array length. Wrapped mutators update
+  // keysRef before the form value changes, so a length mismatch here means the
+  // array was changed externally. We cannot know which indexes changed, so
+  // regenerate all keys rather than reusing keys for the wrong items.
   const currentLength = length || 0
-  if (keysRef.current.length < currentLength) {
-    // Items were added externally — generate stable keys for new items
-    while (keysRef.current.length < currentLength) {
-      keysRef.current.push(`ff-key-${keyCounter.current++}`)
-    }
-  } else if (keysRef.current.length > currentLength) {
-    // Items were removed externally — trim keys
-    keysRef.current = keysRef.current.slice(0, currentLength)
+  if (keysRef.current.length !== currentLength) {
+    keysRef.current = Array.from(
+      { length: currentLength },
+      () => `ff-key-${keyCounter.current++}`
+    )
   }
 
   // Wrap mutators to keep keysRef in sync with array mutations
@@ -129,6 +128,10 @@ const useFieldArray = (
   }
 
   const insert = (index: number, value: any) => {
+    const len = keysRef.current.length
+    if (!Number.isInteger(index) || index < 0 || index > len) {
+      return undefined
+    }
     const newKeys = [...keysRef.current]
     newKeys.splice(index, 0, `ff-key-${keyCounter.current++}`)
     keysRef.current = newKeys
@@ -136,6 +139,10 @@ const useFieldArray = (
   }
 
   const remove = (index: number) => {
+    const len = keysRef.current.length
+    if (!Number.isInteger(index) || index < 0 || index >= len) {
+      return undefined
+    }
     const newKeys = [...keysRef.current]
     newKeys.splice(index, 1)
     keysRef.current = newKeys
@@ -157,7 +164,7 @@ const useFieldArray = (
       from >= len ||
       to >= len
     ) {
-      return (mutators as any).move(from, to)
+      return undefined
     }
     const newKeys = [...keysRef.current]
     const [moved] = newKeys.splice(from, 1)
@@ -176,7 +183,7 @@ const useFieldArray = (
       indexA >= len ||
       indexB >= len
     ) {
-      return (mutators as any).swap(indexA, indexB)
+      return undefined
     }
     const newKeys = [...keysRef.current]
     ;[newKeys[indexA], newKeys[indexB]] = [newKeys[indexB], newKeys[indexA]]

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useForm, useField } from 'react-final-form'
 import { fieldSubscriptionItems, ARRAY_ERROR } from 'final-form'
 import { Mutators } from 'final-form-arrays'
@@ -91,6 +91,77 @@ const useFieldArray = (
   // Create a new meta object that excludes length, preserving lazy getters
   const metaWithoutLength = copyPropertyDescriptors(meta, {} as any, ['length'])
 
+  // Stable keys for React reconciliation (fix #116: indexes-as-keys break components)
+  // Each item gets a unique string ID that persists through its lifetime in the array,
+  // regardless of index shifts caused by insert/remove/move operations.
+  const keyCounter = useRef(0)
+  const keysRef = useRef<string[]>([])
+
+  // Sync keys array length with actual field array length.
+  // If external code adds items (e.g., initialValues), generate new keys for them.
+  const currentLength = length || 0
+  if (keysRef.current.length < currentLength) {
+    // Items were added externally — generate stable keys for new items
+    while (keysRef.current.length < currentLength) {
+      keysRef.current.push(`ff-key-${keyCounter.current++}`)
+    }
+  } else if (keysRef.current.length > currentLength) {
+    // Items were removed externally — trim keys
+    keysRef.current = keysRef.current.slice(0, currentLength)
+  }
+
+  // Wrap mutators to keep keysRef in sync with array mutations
+  const stableKeys = keysRef.current
+
+  const push = (...args: any[]) => {
+    keysRef.current = [...keysRef.current, `ff-key-${keyCounter.current++}`]
+    return (mutators as any).push(...args)
+  }
+
+  const pop = (...args: any[]) => {
+    keysRef.current = keysRef.current.slice(0, -1)
+    return (mutators as any).pop(...args)
+  }
+
+  const unshift = (...args: any[]) => {
+    keysRef.current = [`ff-key-${keyCounter.current++}`, ...keysRef.current]
+    return (mutators as any).unshift(...args)
+  }
+
+  const insert = (index: number, value: any) => {
+    const newKeys = [...keysRef.current]
+    newKeys.splice(index, 0, `ff-key-${keyCounter.current++}`)
+    keysRef.current = newKeys
+    return (mutators as any).insert(index, value)
+  }
+
+  const remove = (index: number) => {
+    const newKeys = [...keysRef.current]
+    newKeys.splice(index, 1)
+    keysRef.current = newKeys
+    return (mutators as any).remove(index)
+  }
+
+  const shift = (...args: any[]) => {
+    keysRef.current = keysRef.current.slice(1)
+    return (mutators as any).shift(...args)
+  }
+
+  const move = (from: number, to: number) => {
+    const newKeys = [...keysRef.current]
+    const [moved] = newKeys.splice(from, 1)
+    newKeys.splice(to, 0, moved)
+    keysRef.current = newKeys
+    return (mutators as any).move(from, to)
+  }
+
+  const swap = (indexA: number, indexB: number) => {
+    const newKeys = [...keysRef.current]
+    ;[newKeys[indexA], newKeys[indexB]] = [newKeys[indexB], newKeys[indexA]]
+    keysRef.current = newKeys
+    return (mutators as any).swap(indexA, indexB)
+  }
+
   const forEach = (iterator: (name: string, index: number) => void): void => {
     // required || for Flow, but results in uncovered line in Jest/Istanbul
     // istanbul ignore next
@@ -114,13 +185,27 @@ const useFieldArray = (
   // Don't spread fieldState, extract only what we need
   const { meta: _meta, input: _input, ...restFieldState } = fieldState
 
+  // Build the mutators object, overriding the key-aware wrappers
+  const wrappedMutators = {
+    ...(mutators as any),
+    push,
+    pop,
+    unshift,
+    insert,
+    remove,
+    shift,
+    move,
+    swap
+  }
+
   return {
     fields: {
       name,
       forEach,
-      length: length || 0,
+      length: currentLength,
       map,
-      ...(mutators as any),
+      keys: [...stableKeys],
+      ...wrappedMutators,
       ...restFieldState,
       value: input.value
     } as any,
@@ -128,4 +213,4 @@ const useFieldArray = (
   }
 }
 
-export default useFieldArray 
+export default useFieldArray


### PR DESCRIPTION
## Problem

When using field names (e.g. `customers[0]`) or indexes as React `key` props in a FieldArray, removing or inserting items causes React to re-use components rather than properly destroy/create them. This is because index-based keys shift when the array is mutated.

This has been a long-standing issue (#116, open since 2019) with 16 reactions and 24 comments — high community impact.

## Solution

Add a `fields.keys` array to `FieldArrayRenderProps`. Each element is a stable unique string ID (format: `ff-key-N`) that:
- Is generated when the item is first added to the array
- Persists through the item's lifetime regardless of index changes from insert/remove/move operations
- Is kept in sync across all mutator operations (push, pop, unshift, insert, remove, shift, move, swap)

## Usage

```tsx
<FieldArray name="customers">
  {({ fields }) =>
    fields.map((name, index) => (
      // Use fields.keys[index] instead of index or name as the React key
      <CustomerRow key={fields.keys[index]} name={name} index={index} />
    ))
  }
</FieldArray>
```

## Changes

- `src/useFieldArray.ts` — Added stable key tracking using `useRef`. All mutators are wrapped to update keys accordingly. External array changes (e.g. from `initialValues`) are synced by comparing key count with field length on each render.
- `src/types.ts` — Added `keys: string[]` to `FieldArrayRenderProps.fields`
- `src/useFieldArray.test.tsx` — 6 new tests covering push, pop, shift, unshift, insert, remove, move, and swap key management

## Test Results

All 47 tests pass with 100% coverage on modified files.

Fixes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array fields now expose stable, unique per-item keys so item identities persist across all array mutations, improving React reconciliation and reducing UI glitches during add/remove/move operations.

* **Tests**
  * Added comprehensive tests verifying keys remain stable, unique, and correctly updated across push, pop, insert, remove, move, swap, shift, and unshift scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->