### PR TITLE
Fix FieldArray validation masking field errors

### DIFF
--- a/src/FieldArray.test.tsx
+++ b/src/FieldArray.test.tsx
@@ -297,6 +297,54 @@ describe('FieldArray', () => {
     expect(callAfterPush[0].meta.error).toBe('Too long')
   })
 
+  it('should not block field-level errors when array validation returns only undefined entries', () => {
+    const validateName = jest.fn((value) =>
+      value === 'bad' ? 'Name cannot be bad' : undefined
+    )
+
+    const { getByTestId } = render(
+      <Form
+        onSubmit={onSubmitMock}
+        mutators={arrayMutators as any}
+        subscription={{}}
+        initialValues={{ foo: [{ name: '' }] }}
+      >
+        {() => (
+          <form>
+            <FieldArray name="foo" validate={() => [undefined]}>
+              {({ fields }) =>
+                fields.map((name) => (
+                  <Field
+                    key={name}
+                    name={`${name}.name`}
+                    validate={validateName}
+                    subscription={{ error: true, value: true }}
+                  >
+                    {({ input, meta }) => (
+                      <div>
+                        <input data-testid={input.name} {...input} />
+                        {meta.error && (
+                          <span data-testid="field-error">{meta.error}</span>
+                        )}
+                      </div>
+                    )}
+                  </Field>
+                ))
+              }
+            </FieldArray>
+          </form>
+        )}
+      </Form>
+    )
+
+    fireEvent.change(getByTestId('foo[0].name'), {
+      target: { value: 'bad' }
+    })
+
+    expect(validateName).toHaveBeenCalled()
+    expect(getByTestId('field-error')).toHaveTextContent('Name cannot be bad')
+  })
+
   it('should provide forEach', () => {
     const renderArray = jest.fn(() => <div />)
     render(

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -14,6 +14,22 @@ import copyPropertyDescriptors from './copyPropertyDescriptors'
 // Users who need additional meta (e.g. touched, dirty) should pass subscription explicitly.
 const defaultSubscription: FieldSubscription = { length: true, value: true, error: true }
 
+const hasError = (error: any): boolean => {
+  if (error === undefined) {
+    return false
+  }
+  if (Array.isArray(error)) {
+    if ((error as any)[ARRAY_ERROR] !== undefined) {
+      return true
+    }
+    return error.some(hasError)
+  }
+  return true
+}
+
+const normalizeArrayError = (error: any): any =>
+  Array.isArray(error) && !hasError(error) ? undefined : error
+
 const useFieldArray = (
   name: string,
   {
@@ -51,7 +67,7 @@ const useFieldArray = (
           if (rawError && typeof rawError.then === 'function') {
             return rawError.then((error: any) => {
               if (!error || Array.isArray(error)) {
-                return error
+                return normalizeArrayError(error)
               } else {
                 const arrayError: any[] = []
                 // gross, but we have to set a string key on the array
@@ -64,7 +80,7 @@ const useFieldArray = (
           // Synchronous validator - process immediately
           const error = rawError
           if (!error || Array.isArray(error)) {
-            return error
+            return normalizeArrayError(error)
           } else {
             const arrayError: any[] = []
             // gross, but we have to set a string key on the array


### PR DESCRIPTION
## Summary
- Normalize FieldArray validation arrays that contain no actual errors to undefined
- Preserve array-level errors, nested errors, and ARRAY_ERROR values
- Add a regression test for initialValue rows where FieldArray validate returns [undefined]

Fixes #163

## Test
- yarn test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling in FieldArray components. Field-level validation errors now display correctly when array-level validation is active. Array-level and field-level validations no longer interfere with each other. Users receive complete validation feedback for all fields and array items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->