### PR TITLE
ci: update lock threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,8 +16,10 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v3
+      # dessant/lock-threads pinned to commit 89ae32b08ed1a541efecbab17912962a5e38981c
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c
         with:
+          process-only: "issues, prs"
           issue-inactive-days: "365"
           issue-lock-reason: "resolved"
           pr-inactive-days: "365"


### PR DESCRIPTION
## Summary
- Updates dessant/lock-threads from v3 to a pinned v6 commit
- Restricts processing to issues and PRs, matching the existing permissions
- Fixes the old action rejecting GitHub's longer token and avoids the Node 20 deprecation warning

## Test Plan
- Parsed .github/workflows/lock.yml with Ruby YAML